### PR TITLE
Remove ember get owner polyfill

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import Errors from 'ember-validations/errors';
 import Base from 'ember-validations/validators/base';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   A: emberArray,
@@ -15,7 +14,8 @@ const {
   isNone,
   isPresent,
   set,
-  warn
+  warn,
+  getOwner
 } = Ember;
 
 const setValidityMixin = Mixin.create({

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-getowner-polyfill": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.1.0"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This library is no longer maintained, but we've been using it in Aviapp for a fairly long time.

It had an older version of the library ember-getowner-polyfill which contained code that breaks with future Ember versions. However, from Ember 2.3 on, that library is no longer needed and you can simply use `Ember.getOwner`.